### PR TITLE
Add ScriptingRuntime trait, add Lua support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ bevy = { default-features = false, version = "0.11.0", features = [
 serde = "1.0.162"
 rhai = { version = "1.14.0", features = ["sync", "internals", "unchecked"] }
 thiserror = "1.0.40"
+rlua = "0.19.7"

--- a/examples/call_function_from_rust.rs
+++ b/examples/call_function_from_rust.rs
@@ -1,5 +1,5 @@
 use bevy::{app::AppExit, ecs::event::ManualEventReader, prelude::*};
-use bevy_scriptum::{prelude::*, Script, ScriptData, ScriptingRuntime};
+use bevy_scriptum::{prelude::*, Runtimes, Script, ScriptData};
 
 fn main() {
     App::new()
@@ -38,7 +38,7 @@ fn startup(mut commands: Commands, assets_server: Res<AssetServer>) {
 
 fn call_rhai_on_update_from_rust(
     mut scripted_entities: Query<(Entity, &mut ScriptData)>,
-    mut scripting_runtime: ResMut<ScriptingRuntime>,
+    mut scripting_runtime: ResMut<Runtimes>,
 ) {
     for (entity, mut script_data) in &mut scripted_entities {
         scripting_runtime

--- a/examples/custom_type.rs
+++ b/examples/custom_type.rs
@@ -25,7 +25,6 @@ fn startup(
     let runtimes = runtimes_resource.runtimes_mut();
 
     for runtime in runtimes {
-        todo!();
         // runtime
         //     .register_type_with_name::<MyType>("MyType")
         //     // Register a method on MyType

--- a/examples/custom_type.rs
+++ b/examples/custom_type.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_scriptum::{prelude::*, Script, ScriptingRuntime};
+use bevy_scriptum::{prelude::*, Runtimes, Script};
 
 fn main() {
     App::new()
@@ -19,19 +19,22 @@ struct MyType {
 
 fn startup(
     mut commands: Commands,
-    mut scripting_runtime: ResMut<ScriptingRuntime>,
+    mut runtimes_resource: ResMut<Runtimes>,
     assets_server: Res<AssetServer>,
 ) {
-    let engine = scripting_runtime.engine_mut();
+    let runtimes = runtimes_resource.runtimes_mut();
 
-    engine
-        .register_type_with_name::<MyType>("MyType")
-        // Register a method on MyType
-        .register_fn("my_method", |my_type_instance: &mut MyType| {
-            my_type_instance.my_field
-        })
-        // Register a "constructor" for MyType
-        .register_fn("new_my_type", || MyType { my_field: 42 });
+    for runtime in runtimes {
+        todo!();
+        // runtime
+        //     .register_type_with_name::<MyType>("MyType")
+        //     // Register a method on MyType
+        //     .register_fn("my_method", |my_type_instance: &mut MyType| {
+        //         my_type_instance.my_field
+        //     })
+        //     // Register a "constructor" for MyType
+        //     .register_fn("new_my_type", || MyType { my_field: 42 });
+    }
 
     commands.spawn(Script::new(assets_server.load("examples/custom_type.rhai")));
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,6 +5,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(ScriptingPlugin::default())
+        .add_script_runtime(bevy_scriptum::runtimes::rhai::Runtime::new())
         .add_script_function(String::from("hello_bevy"), || {
             println!("hello bevy, called from script");
         })

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -8,20 +8,20 @@ use serde::Deserialize;
 /// A script that can be loaded by the [crate::ScriptingPlugin].
 #[derive(Debug, Deserialize, TypeUuid, TypePath)]
 #[uuid = "3ed4b68b-4f5d-4d82-96f6-5194e358921a"]
-pub struct RhaiScript(pub String);
+pub struct ScriptAsset(pub String);
 
 /// A loader for [RhaiScript] assets.
 #[derive(Default)]
-pub struct RhaiScriptLoader;
+pub struct ScriptLoader;
 
-impl AssetLoader for RhaiScriptLoader {
+impl AssetLoader for ScriptLoader {
     fn load<'a>(
         &'a self,
         bytes: &'a [u8],
         load_context: &'a mut LoadContext,
     ) -> BoxedFuture<'a, Result<(), bevy::asset::Error>> {
         Box::pin(async move {
-            let rhai_script = RhaiScript(String::from_utf8(bytes.to_vec())?);
+            let rhai_script = ScriptAsset(String::from_utf8(bytes.to_vec())?);
             load_context.set_default_asset(LoadedAsset::new(rhai_script));
             Ok(())
         })

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,11 +1,11 @@
 use bevy::prelude::*;
 
-use super::assets::RhaiScript;
+use super::assets::ScriptAsset;
 
 /// A component that represents a script.
 #[derive(Component)]
 pub struct Script {
-    pub script: Handle<RhaiScript>,
+    pub script: Handle<ScriptAsset>,
 }
 
 /// A component that represents the data of a script. It stores the [rhai::Scope](basically the state of the script, any declared variable etc.)
@@ -18,7 +18,7 @@ pub struct ScriptData {
 
 impl Script {
     /// Create a new script component from a handle to a [RhaiScript] obtained using [AssetServer].
-    pub fn new(script: Handle<RhaiScript>) -> Self {
+    pub fn new(script: Handle<ScriptAsset>) -> Self {
         Self { script }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub use assets::ScriptAsset;
 
 use bevy::prelude::*;
 use callback::{Callback, RegisterCallbackFunction};
-use rhai::{CallFnOptions, Dynamic, Engine, EvalAltResult, FuncArgs, ParseError, Scope};
+use rhai::{Dynamic, EvalAltResult, FuncArgs, ParseError, Scope};
 use systems::{init_callbacks, init_engine, log_errors, process_calls};
 use thiserror::Error;
 
@@ -264,24 +264,10 @@ impl Runtimes {
         for runtime in &mut self.runtimes {
             let ast = script_data.ast.clone();
             let scope = &mut script_data.scope;
-            scope.push(ENTITY_VAR_NAME, entity);
-            // let options = CallFnOptions::new().eval_ast(false);
 
-            let result = runtime.call_fn(&ast, scope, function_name, parsed_args.clone());
-            // let result = self.runtimes.call_fn_with_options::<Dynamic>(
-            //     options,
-            //     scope,
-            //     &ast,
-            //     function_name,
-            //     args,
-            // );
-            // scope.remove::<Entity>(ENTITY_VAR_NAME).unwrap();
-            // if let Err(err) = result {
-            //     match *err {
-            //         rhai::EvalAltResult::ErrorFunctionNotFound(name, _) if name == function_name => {}
-            //         e => Err(Box::new(e))?,
-            //     }
-            // }
+            runtime.set_global_variable(ENTITY_VAR_NAME, Dynamic::from(entity));
+            let _ = runtime.call_fn(&ast, scope, function_name, parsed_args.clone())?;
+            runtime.unset_global_variable(ENTITY_VAR_NAME);
         }
         Ok(())
     }
@@ -329,6 +315,8 @@ pub trait ScriptingRuntime: Sync + Send {
         function_name: &str,
         args: Vec<Dynamic>,
     ) -> Result<Dynamic, ScriptingError>;
+    fn set_global_variable(&mut self, name: &str, value: Dynamic);
+    fn unset_global_variable(&mut self, name: &str);
 }
 
 impl AddScriptFunctionAppExt for App {

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -13,8 +13,8 @@ pub(crate) struct PromiseCallback {
 /// Internal representation of a Promise.
 pub(crate) struct PromiseInner {
     pub(crate) callbacks: Vec<PromiseCallback>,
-    #[allow(deprecated)]
-    pub(crate) context_data: NativeCallContextStore,
+    // #[allow(deprecated)]
+    // pub(crate) context_data: NativeCallContextStore,
 }
 
 /// A struct that represents a Promise.
@@ -32,18 +32,18 @@ impl PromiseInner {
     ) -> Result<(), Box<EvalAltResult>> {
         for callback in &self.callbacks {
             let f = callback.callback.clone_cast::<FnPtr>();
-            #[allow(deprecated)]
-            let context = self.context_data.create_context(engine);
-            let next_val = if val.is_unit() {
-                f.call_raw(&context, None, [])?
-            } else {
-                f.call_raw(&context, None, [val.clone()])?
-            };
-            callback
-                .following_promise
-                .lock()
-                .unwrap()
-                .resolve(engine, next_val)?;
+            // #[allow(deprecated)]
+            // let context = self.context_data.create_context(engine);
+            // let next_val = if val.is_unit() {
+            //     f.call_raw(&context, None, [])?
+            // } else {
+            //     f.call_raw(&context, None, [val.clone()])?
+            // };
+            // callback
+            //     .following_promise
+            //     .lock()
+            //     .unwrap()
+            //     .resolve(engine, next_val)?;
         }
         Ok(())
     }
@@ -67,7 +67,7 @@ impl Promise {
         let mut inner = self.inner.lock().unwrap();
         let following_inner = Arc::new(Mutex::new(PromiseInner {
             callbacks: vec![],
-            context_data: inner.context_data.clone(),
+            // context_data: inner.context_data.clone(),
         }));
 
         inner.callbacks.push(PromiseCallback {

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -4,6 +4,8 @@ use std::sync::{Arc, Mutex};
 use rhai::{Dynamic, NativeCallContextStore};
 use rhai::{EvalAltResult, FnPtr};
 
+use crate::ScriptingRuntime;
+
 /// A struct that represents a function that will get called when the Promise is resolved.
 pub(crate) struct PromiseCallback {
     callback: Dynamic,
@@ -27,7 +29,7 @@ impl PromiseInner {
     /// Resolve the Promise. This will call all the callbacks that were added to the Promise.
     fn resolve(
         &mut self,
-        engine: &mut rhai::Engine,
+        runtime: &Box<dyn ScriptingRuntime>,
         val: Dynamic,
     ) -> Result<(), Box<EvalAltResult>> {
         for callback in &self.callbacks {
@@ -53,11 +55,11 @@ impl Promise {
     /// Acquire [Mutex] for writing the promise and resolve it. Call will be forwarded to [PromiseInner::resolve].
     pub(crate) fn resolve(
         &mut self,
-        engine: &mut rhai::Engine,
+        runtime: &Box<dyn ScriptingRuntime>,
         val: Dynamic,
     ) -> Result<(), Box<EvalAltResult>> {
         if let Ok(mut inner) = self.inner.lock() {
-            inner.resolve(engine, val)?;
+            inner.resolve(runtime, val)?;
         }
         Ok(())
     }

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 #[allow(deprecated)]
-use rhai::{Dynamic, NativeCallContextStore};
+use rhai::Dynamic;
 use rhai::{EvalAltResult, FnPtr};
 
 use crate::ScriptingRuntime;

--- a/src/runtimes/mod.rs
+++ b/src/runtimes/mod.rs
@@ -1,0 +1,1 @@
+pub mod rhai;

--- a/src/runtimes/rhai.rs
+++ b/src/runtimes/rhai.rs
@@ -60,4 +60,14 @@ impl ScriptingRuntime for Runtime {
         // commands.entity(entity).insert(ScriptData { ast, scope });
         Ok(())
     }
+
+    fn call_fn(
+        &mut self,
+        ast: &rhai::AST,
+        scope: &mut rhai::Scope,
+        function_name: &str,
+        args: Vec<rhai::Dynamic>,
+    ) -> Result<rhai::Dynamic, ScriptingError> {
+        todo!()
+    }
 }

--- a/src/runtimes/rhai.rs
+++ b/src/runtimes/rhai.rs
@@ -1,0 +1,63 @@
+use crate::{ScriptingError, ScriptingRuntime};
+
+pub struct Runtime {
+    rhai_engine: rhai::Engine,
+}
+
+impl Runtime {
+    pub fn new() -> Self {
+        Runtime {
+            rhai_engine: rhai::Engine::new(),
+        }
+    }
+}
+
+impl ScriptingRuntime for Runtime {
+    fn register_fn(
+        &mut self,
+        name: String,
+        arg_types: Vec<std::any::TypeId>,
+        callback: Box<dyn Fn() -> () + Send + Sync>,
+    ) {
+        self.rhai_engine
+            .register_raw_fn(name, arg_types, move |context, args| {
+                callback();
+                // #[allow(deprecated)]
+                // let context_data = context.store_data();
+                // let promise = Promise {
+                //     inner: Arc::new(Mutex::new(PromiseInner {
+                //         callbacks: vec![],
+                //         context_data,
+                //     })),
+                // };
+
+                // let mut calls = callback.calls.lock().unwrap();
+                // calls.push(FunctionCallEvent {
+                //     promise: promise.clone(),
+                //     params: args.iter_mut().map(|arg| arg.clone()).collect(),
+                // });
+                // Ok(promise)
+                Ok(())
+            });
+    }
+
+    fn eval(&mut self, code: &str) -> Result<(), ScriptingError> {
+        let mut scope = rhai::Scope::new();
+        // scope.push(ENTITY_VAR_NAME, entity);
+
+        // let engine = &runtimes_resource.runtimes;
+        let ast = self
+            .rhai_engine
+            .compile_with_scope(&scope, code)
+            .map_err(ScriptingError::CompileError)?;
+
+        self.rhai_engine
+            .run_ast_with_scope(&mut scope, &ast)
+            .map_err(ScriptingError::RuntimeError)?;
+
+        // scope.remove::<Entity>(ENTITY_VAR_NAME).unwrap();
+
+        // commands.entity(entity).insert(ScriptData { ast, scope });
+        Ok(())
+    }
+}

--- a/src/runtimes/rhai.rs
+++ b/src/runtimes/rhai.rs
@@ -1,4 +1,7 @@
-use crate::{ScriptingError, ScriptingRuntime};
+use bevy::prelude::Entity;
+use rhai::{CallFnOptions, Dynamic};
+
+use crate::{ScriptingError, ScriptingRuntime, ENTITY_VAR_NAME};
 
 pub struct Runtime {
     rhai_engine: rhai::Engine,
@@ -43,9 +46,7 @@ impl ScriptingRuntime for Runtime {
 
     fn eval(&mut self, code: &str) -> Result<(), ScriptingError> {
         let mut scope = rhai::Scope::new();
-        // scope.push(ENTITY_VAR_NAME, entity);
 
-        // let engine = &runtimes_resource.runtimes;
         let ast = self
             .rhai_engine
             .compile_with_scope(&scope, code)
@@ -55,9 +56,6 @@ impl ScriptingRuntime for Runtime {
             .run_ast_with_scope(&mut scope, &ast)
             .map_err(ScriptingError::RuntimeError)?;
 
-        // scope.remove::<Entity>(ENTITY_VAR_NAME).unwrap();
-
-        // commands.entity(entity).insert(ScriptData { ast, scope });
         Ok(())
     }
 
@@ -68,6 +66,24 @@ impl ScriptingRuntime for Runtime {
         function_name: &str,
         args: Vec<rhai::Dynamic>,
     ) -> Result<rhai::Dynamic, ScriptingError> {
+        // scope.push(ENTITY_VAR_NAME, entity);
+        let options = CallFnOptions::new().eval_ast(false);
+        let result = self.rhai_engine.call_fn_with_options::<Dynamic>(
+            options,
+            scope,
+            &ast,
+            function_name,
+            args,
+        )?;
+        // scope.remove::<Entity>(ENTITY_VAR_NAME).unwrap();
+        return Ok(result);
+    }
+
+    fn set_global_variable(&mut self, name: &str, value: Dynamic) {
+        todo!()
+    }
+
+    fn unset_global_variable(&mut self, name: &str) {
         todo!()
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -180,8 +180,8 @@ pub(crate) fn process_calls(world: &mut World) -> Result<(), ScriptingError> {
             let mut runtimes_resource = world
                 .get_resource_mut::<Runtimes>()
                 .ok_or(ScriptingError::NoRuntimeResource)?;
-            for runtime in &runtimes_resource.runtimes {
-                // call.promise.resolve(&mut runtime, val)?;
+            for mut runtime in &runtimes_resource.runtimes {
+                call.promise.resolve(&mut runtime, val.clone())?;
             }
         }
     }


### PR DESCRIPTION

## Proposed Changes

  - adds support for lua
  - adds `ScriptingRuntime` trait, which allows downstream implementers to add custom scripting runtime for scripting in any language
  - add `add_script_runtime` function, which allows adding instance of `ScriptingRuntime` object to Bevy app 
 