### PR TITLE
Apply side effects for tuple args systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_scriptum"
 authors = ["Jaroslaw Konik <konikjar@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -85,7 +85,9 @@ macro_rules! impl_tuple {
                     let args = (
                         $(args.0.get($idx).unwrap().clone_cast::<$t>(), )+
                     );
-                    Dynamic::from(inner_system.run(args, world))
+                    let result = inner_system.run(args, world);
+                    inner_system.apply_deferred(world);
+                    Dynamic::from(result)
                 };
                 let system = IntoSystem::into_system(system_fn);
                 CallbackSystem {


### PR DESCRIPTION
Fixes #7 

Deferred side effects(Commands) that were pushed in scripting exposed
systems were only applied for argument-less systems.
This PR fixes this by applying deferred side effects in macro that
implement functions with arguments.