### PR TITLE
Added initial support for bevy 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ lua = ["mlua/luajit"]
 rhai = ["dep:rhai"]
 
 [dependencies]
-bevy = { default-features = false, version = "0.15", features = ["bevy_asset"] }
+bevy = { default-features = false, version = "0.16.0", features = ["bevy_asset", "bevy_log", "std"] }
 serde = "1.0.162"
 rhai = { version = "1.14.0", features = [
     "sync",

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The examples live in `examples` directory and their corresponding scripts live i
 
 | bevy version | bevy_scriptum version |
 |--------------|-----------------------|
+| 0.16         | 0.8                   |
 | 0.15         | 0.7                   |
 | 0.14         | 0.6                   |
 | 0.13         | 0.4-0.5               |

--- a/examples/lua/call_function_from_rust.rs
+++ b/examples/lua/call_function_from_rust.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_systems(Update, call_lua_on_update_from_rust)
         .add_scripting::<LuaRuntime>(|runtime| {
             runtime.add_function(String::from("quit"), |mut exit: EventWriter<AppExit>| {
-                exit.send(AppExit::Success);
+                exit.write(AppExit::Success);
             });
         })
         .run();

--- a/examples/lua/promises.rs
+++ b/examples/lua/promises.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_scripting::<LuaRuntime>(|builder| {
             builder.add_function(
                 String::from("get_player_name"),
-                |player_names: Query<&Name, With<Player>>| player_names.single().to_string(),
+                |player_names: Query<&Name, With<Player>>| player_names.single().expect("Missing player_names").to_string(),
             );
         })
         .add_systems(Startup, startup)

--- a/examples/lua/side_effects.rs
+++ b/examples/lua/side_effects.rs
@@ -38,6 +38,6 @@ fn print_entity_names_and_quit(query: Query<&Name>, mut exit: EventWriter<AppExi
         for e in &query {
             println!("{}", e);
         }
-        exit.send(AppExit::Success);
+        exit.write(AppExit::Success);
     }
 }

--- a/examples/rhai/call_function_from_rust.rs
+++ b/examples/rhai/call_function_from_rust.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_systems(Update, call_rhai_on_update_from_rust)
         .add_scripting::<RhaiRuntime>(|runtime| {
             runtime.add_function(String::from("quit"), |mut exit: EventWriter<AppExit>| {
-                exit.send(AppExit::Success);
+                exit.write(AppExit::Success);
             });
         })
         .run();

--- a/examples/rhai/promises.rs
+++ b/examples/rhai/promises.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_scripting::<RhaiRuntime>(|builder| {
             builder.add_function(
                 String::from("get_player_name"),
-                |player_names: Query<&Name, With<Player>>| player_names.single().to_string(),
+                |player_names: Query<&Name, With<Player>>| player_names.single().expect("Missing player_names").to_string(),
             );
         })
         .add_systems(Startup, startup)

--- a/examples/rhai/side_effects.rs
+++ b/examples/rhai/side_effects.rs
@@ -36,6 +36,6 @@ fn print_entity_names_and_quit(query: Query<&Name>, mut exit: EventWriter<AppExi
         for e in &query {
             println!("{}", e);
         }
-        exit.send(AppExit::Success);
+        exit.write(AppExit::Success);
     }
 }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use bevy::{
     asset::{io::Reader, Asset, AssetLoader, LoadContext},
-    utils::ConditionalSendFuture,
+    tasks::ConditionalSendFuture,
 };
 
 /// A loader for script assets.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use bevy::{app::MainScheduleOrder, ecs::schedule::ScheduleLabel, prelude::*};
+use bevy::{app::MainScheduleOrder, ecs::{component::Mutable, schedule::ScheduleLabel}, prelude::*};
 use callback::{Callback, IntoCallbackSystem};
 use systems::{init_callbacks, log_errors, process_calls};
 use thiserror::Error;
@@ -290,7 +290,7 @@ pub enum ScriptingError {
 pub trait Runtime: Resource + Default {
     type Schedule: ScheduleLabel + Debug + Clone + Eq + Hash + Default;
     type ScriptAsset: Asset + From<String> + GetExtensions;
-    type ScriptData: Component;
+    type ScriptData: Component<Mutability = Mutable>;
     type CallContext: Send + Clone;
     type Value: Send + Clone;
     type RawEngine;

--- a/src/runtimes/lua.rs
+++ b/src/runtimes/lua.rs
@@ -1,6 +1,6 @@
 use bevy::{
     asset::Asset,
-    ecs::{component::Component, entity::Entity, schedule::ScheduleLabel, system::Resource},
+    ecs::{component::Component, entity::Entity, schedule::ScheduleLabel, resource::Resource},
     math::Vec3,
     reflect::TypePath,
 };

--- a/src/runtimes/rhai.rs
+++ b/src/runtimes/rhai.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use bevy::{
     asset::Asset,
-    ecs::{component::Component, entity::Entity, schedule::ScheduleLabel, system::Resource},
+    ecs::{component::Component, entity::Entity, schedule::ScheduleLabel, resource::Resource},
     math::Vec3,
     reflect::TypePath,
 };

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, utils::tracing};
+use bevy::{prelude::*, log::tracing};
 use std::{
     fmt::Display,
     sync::{Arc, Mutex},

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,7 +49,7 @@ fn call_script_on_update_from_rust<R: Runtime>(
 ) where
     (): for<'a> FuncArgs<'a, R::Value, R>,
 {
-    let (entity, mut script_data) = scripted_entities.single_mut();
+    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
     scripting_runtime
         .call_fn("test_func", &mut script_data, entity, ())
         .unwrap();
@@ -83,7 +83,7 @@ macro_rules! scripting_tests {
                 .to_string(),
                 |mut scripted_entities: Query<(Entity, &mut <$runtime as Runtime>::ScriptData)>,
                  scripting_runtime: ResMut<$runtime>| {
-                    let (entity, mut script_data) = scripted_entities.single_mut();
+                    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
                     scripting_runtime
                         .call_fn("test_func", &mut script_data, entity, vec![1])
                         .unwrap();
@@ -178,7 +178,7 @@ macro_rules! scripting_tests {
                 .to_string(),
                 |mut scripted_entities: Query<(Entity, &mut <$runtime as Runtime>::ScriptData)>,
                  scripting_runtime: ResMut<$runtime>| {
-                    let (entity, mut script_data) = scripted_entities.single_mut();
+                    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
                     scripting_runtime
                         .call_fn("test_func", &mut script_data, entity, vec![1])
                         .unwrap();
@@ -203,7 +203,7 @@ macro_rules! scripting_tests {
                 .to_string(),
                 |mut scripted_entities: Query<(Entity, &mut <$runtime as Runtime>::ScriptData)>,
                  scripting_runtime: ResMut<$runtime>| {
-                    let (entity, mut script_data) = scripted_entities.single_mut();
+                    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
                     scripting_runtime
                         .call_fn(
                             "test_func",
@@ -239,7 +239,7 @@ macro_rules! scripting_tests {
                 .to_string(),
                 |mut scripted_entities: Query<(Entity, &mut <$runtime as Runtime>::ScriptData)>,
                  scripting_runtime: ResMut<$runtime>| {
-                    let (entity, mut script_data) = scripted_entities.single_mut();
+                    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
                     scripting_runtime
                         .call_fn("test_func", &mut script_data, entity, vec![1, 2])
                         .unwrap();
@@ -265,7 +265,7 @@ macro_rules! scripting_tests {
                 .to_string(),
                 |mut scripted_entities: Query<(Entity, &mut <$runtime as Runtime>::ScriptData)>,
                  scripting_runtime: ResMut<$runtime>| {
-                    let (entity, mut script_data) = scripted_entities.single_mut();
+                    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
                     let result =
                         scripting_runtime.call_fn("test_func", &mut script_data, entity, ());
                     assert!(result.is_err());
@@ -288,7 +288,7 @@ macro_rules! scripting_tests {
                 .to_string(),
                 |mut scripted_entities: Query<(Entity, &mut <$runtime as Runtime>::ScriptData)>,
                  scripting_runtime: ResMut<$runtime>| {
-                    let (entity, mut script_data) = scripted_entities.single_mut();
+                    let (entity, mut script_data) = scripted_entities.single_mut().unwrap();
                     let result =
                         scripting_runtime.call_fn("does_not_exist", &mut script_data, entity, ());
                     assert!(result.is_err());
@@ -368,7 +368,7 @@ macro_rules! scripting_tests {
 
             app.world_mut()
                 .run_system_once(|tagged: Query<&MyTag>| {
-                    tagged.single();
+                    tagged.single().unwrap();
                 })
                 .unwrap();
         }


### PR DESCRIPTION
Fixes #38 

## Proposed Changes

  - Update `bevy` support to version 0.16.
  - Add `bevy_log` and `std` features to `bevy`, as they were split out from the core library.
  - Follow [migration guide](https://bevyengine.org/learn/migration-guides/0-15-to-0-16) from `bevy`

## Testing
  - No functional changes to the tests
  - All tests pass when running `cargo test --all-features`
  - `cargo doc` passes without errors, though a single existing warning remains.