### PR TITLE
Compile on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,7 @@ impl<R: Runtime> Default for Callbacks<R> {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, unix))]
 pub extern "C" fn is_rdynamic_linking() -> bool {
     unsafe {
         // Get a function pointer to itself
@@ -522,6 +522,12 @@ pub extern "C" fn is_rdynamic_linking() -> bool {
 
         result != 0 && !info.dli_sname.is_null()
     }
+}
+
+#[cfg(any(not(debug_assertions), not(unix)))]
+pub extern "C" fn is_rdynamic_linking() -> bool {
+    // On Windows or in release builds, return a default value
+    false
 }
 
 pub mod prelude {


### PR DESCRIPTION
Fixes #

added `cfg(unix)` for `is_rdynamic_linking` to avoid Unix specific calls on non Unix configuration.

I'll be honest I don't know if it matters but I just made it return false for windows so I could use the crate locally.

I wasn't able to test ruby on windows or get ruby working for that matter.